### PR TITLE
Move default-validator stages to seperate config file

### DIFF
--- a/validators/overlays/09/classes/default-validator.xml
+++ b/validators/overlays/09/classes/default-validator.xml
@@ -22,11 +22,9 @@
         p:XSLResource="classpath:_rules/check_entityid_prefix.xsl"/>
 
     <bean id="pipeline" parent="mda.SimplePipeline">
-        <property name="stages">
-            <list>
-                <ref bean="check_entityid_prefix"/>
-            </list>
-        </property>
+        <property name="stages" ref="default_validator_stages"/>
     </bean>
+
+    <import resource="default-validator-stages.xml"/>
 
 </beans>

--- a/validators/overlays/all/classes/default-validator-stages.xml
+++ b/validators/overlays/all/classes/default-validator-stages.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    default-lazy-init="true"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <!-- The list of tests (stages) used by the default validator -->
+    <util:list id="default_validator_stages">
+       <ref bean="check_entityid_prefix"/>
+    </util:list>
+
+</beans>

--- a/validators/overlays/all/classes/default-validator.xml
+++ b/validators/overlays/all/classes/default-validator.xml
@@ -22,11 +22,9 @@
         p:XSLResource="classpath:_rules/check_entityid_prefix.xsl"/>
 
     <bean id="pipeline" parent="mda.SimplePipeline">
-        <property name="stages">
-            <list>
-                <ref bean="check_entityid_prefix"/>
-            </list>
-        </property>
+        <property name="stages" ref="default_validator_stages"/>
     </bean>
+
+    <import resource="default-validator-stages.xml"/>
 
 </beans>


### PR DESCRIPTION
Both 09 and 010 use their own list of stages for the default-validator. However, both lists are the same and are intended to stay in sync. Rather than updating each separate default-validator config each time there is a new stage, they now reference the same list in the new default-validator-stages config.