### PR TITLE
Add GitHub Action to build validator and driver images

### DIFF
--- a/.github/workflows/docker-build-image-all-validators-and-driver.yml
+++ b/.github/workflows/docker-build-image-all-validators-and-driver.yml
@@ -1,0 +1,24 @@
+name: Docker Image CI For All Validators And Driver
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build_docker_images:
+    name: Build driver and validator fleet images
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the 09 Docker image
+      run: docker buildx build validators --file validators/Dockerfile.09 --tag ukf/testbed:0.9 --output type=docker
+    - name: Build the 09x Docker image
+      run: docker buildx build validators --file validators/Dockerfile.09x --tag ukf/testbed:0.9-xalan --output type=docker
+    - name: Build the 010 Docker image
+      run: docker buildx build validators --file validators/Dockerfile.010 --tag ukf/testbed:0.10 --output type=docker
+    - name: Build the 010x Docker image
+      run: docker buildx build validators --file validators/Dockerfile.010x --tag ukf/testbed:0.10-xalan --output type=docker
+    - name: Build the driver Docker image
+      run: docker buildx build driver --tag ukf/testbed-driver:latest --output type=docker


### PR DESCRIPTION
 - Add buildx image building function
 - see https://github.com/ukf/ukf-testbed/issues/5

I added each docker build command to the Action, rather than calling the `build-image` scripts. It seems a tighter integration into the Action workflow. But I can change that if undesirable.