### PR TITLE
Add Test: Check for SAML 2.0 SPs which lack an encryption key

### DIFF
--- a/tests/xml/saml2_enc_key/bad_saml2_sp_enc_key_no_cert.xml
+++ b/tests/xml/saml2_enc_key/bad_saml2_sp_enc_key_no_cert.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test encryption KeyDescriptor but no X509Data. Should fail as no encryption key found. -->
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:remd="http://refeds.org/metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+    xmlns:ukfedlabel="http://ukfederation.org.uk/2006/11/label"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd
+        urn:oasis:names:tc:SAML:metadata:algsupport sstc-saml-metadata-algsupport-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:attribute sstc-metadata-attr.xsd
+        urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:ui sstc-saml-metadata-ui-v1.0.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol sstc-saml-idp-discovery.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:request-init sstc-request-initiation.xsd
+        urn:oasis:names:tc:SAML:2.0:assertion saml-schema-assertion-2.0.xsd
+        urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd
+        http://ukfederation.org.uk/2006/11/label uk-fed-label.xsd
+        http://refeds.org/metadata refeds-metadata.xsd
+        http://www.w3.org/2001/04/xmlenc# xenc-schema.xsd
+        http://www.w3.org/2009/xmlenc11# xenc-schema-11.xsd
+        http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
+    ID="uk000006" entityID="http://idp2.iay.org.uk/idp/shibboleth">
+    <!--
+        This is an "Ian A. Young" IdP for Ian A. Young.
+    -->
+    <Extensions>
+        <ukfedlabel:UKFederationMember orgID="ukforg4590"/>
+        <shibmd:Scope regexp="false">iay.org.uk</shibmd:Scope>
+        <ukfedlabel:Software date="2016-11-17" fullVersion="3.3.0" name="Shibboleth" version="3"/>
+        <ukfedlabel:ExportOptIn date="2009-09-11"/>
+        <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+            registrationInstant="2007-03-30T16:36:00Z">
+            <mdrpi:RegistrationPolicy xml:lang="en"
+                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+        </mdrpi:RegistrationInfo>
+        <mdattr:EntityAttributes xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml:Attribute Name="http://macedir.org/entity-category-support"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>
+    </Extensions>
+     <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+            <Extensions>
+                <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://example.org/Shibboleth.sso/Login"/>
+                <idpdisc:DiscoveryResponse xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://example.org/Shibboleth.sso/Login" index="1"/>
+                <mdui:UIInfo>
+                    <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
+                </mdui:UIInfo>                
+            </Extensions>            
+            <KeyDescriptor use="encryption">
+                <ds:KeyInfo>
+                    <ds:KeyName>example.org</ds:KeyName>
+                </ds:KeyInfo>
+            </KeyDescriptor>            
+            <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/Artifact/SOAP" index="0"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SLO/Artifact"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SLO/POST"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.org/Shibboleth.sso/SLO/Redirect"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/SLO/SOAP"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://example.org/Shibboleth.sso/SAML/Artifact" index="0"/>
+
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://example.org/Shibboleth.sso/SAML/POST" index="1"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SAML2/Artifact" index="2"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
+            
+            <AttributeConsumingService index="1">
+                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+            </AttributeConsumingService>
+        </SPSSODescriptor>
+    <Organization>
+        <OrganizationName xml:lang="en">Ian A. Young</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">Ian A. Young</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">http://iay.org.uk/</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="support">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="technical">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="administrative">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ian@iay.org.uk</EmailAddress>
+    </ContactPerson>
+</EntityDescriptor>

--- a/tests/xml/saml2_enc_key/bad_saml2_sp_enc_key_no_cert.yaml
+++ b/tests/xml/saml2_enc_key/bad_saml2_sp_enc_key_no_cert.yaml
@@ -1,0 +1,4 @@
+expected:
+- status: error
+  component_id: check_saml2
+  message: "SAML 2.0 SP has no encryption key"

--- a/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key.xml
+++ b/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test a signing KeyDescriptor. Should fail as no encryption key will be found. -->
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:remd="http://refeds.org/metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+    xmlns:ukfedlabel="http://ukfederation.org.uk/2006/11/label"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd
+        urn:oasis:names:tc:SAML:metadata:algsupport sstc-saml-metadata-algsupport-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:attribute sstc-metadata-attr.xsd
+        urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:ui sstc-saml-metadata-ui-v1.0.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol sstc-saml-idp-discovery.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:request-init sstc-request-initiation.xsd
+        urn:oasis:names:tc:SAML:2.0:assertion saml-schema-assertion-2.0.xsd
+        urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd
+        http://ukfederation.org.uk/2006/11/label uk-fed-label.xsd
+        http://refeds.org/metadata refeds-metadata.xsd
+        http://www.w3.org/2001/04/xmlenc# xenc-schema.xsd
+        http://www.w3.org/2009/xmlenc11# xenc-schema-11.xsd
+        http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
+    ID="uk000006" entityID="http://idp2.iay.org.uk/idp/shibboleth">
+    <!--
+        This is an "Ian A. Young" IdP for Ian A. Young.
+    -->
+    <Extensions>
+        <ukfedlabel:UKFederationMember orgID="ukforg4590"/>
+        <shibmd:Scope regexp="false">iay.org.uk</shibmd:Scope>
+        <ukfedlabel:Software date="2016-11-17" fullVersion="3.3.0" name="Shibboleth" version="3"/>
+        <ukfedlabel:ExportOptIn date="2009-09-11"/>
+        <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+            registrationInstant="2007-03-30T16:36:00Z">
+            <mdrpi:RegistrationPolicy xml:lang="en"
+                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+        </mdrpi:RegistrationInfo>
+        <mdattr:EntityAttributes xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml:Attribute Name="http://macedir.org/entity-category-support"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>
+    </Extensions>
+     <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+            <Extensions>
+                <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://example.org/Shibboleth.sso/Login"/>
+                <idpdisc:DiscoveryResponse xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://example.org/Shibboleth.sso/Login" index="1"/>
+                <mdui:UIInfo>
+                    <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
+                </mdui:UIInfo>                
+            </Extensions>            
+            <KeyDescriptor use="signing">
+                <ds:KeyInfo>
+                    <ds:KeyName>example.org</ds:KeyName>
+                    <ds:X509Data>
+                        <ds:X509SubjectName>CN=example.org,DC=example,DC=org</ds:X509SubjectName>
+                        <ds:X509Certificate>
+MIIDRjCCAi6gAwIBAgIJAPpEsjMpUtq9MA0GCSqGSIb3DQEBBQUAMFExEzARBgoJ
+kiaJk/IsZAEZFgNuZXQxGjAYBgoJkiaJk/IsZAEZFgpzaGliYm9sZXRoMR4wHAYD
+VQQDExVpc3N1ZXMuc2hpYmJvbGV0aC5uZXQwHhcNMTEwMTA3MTg0MTQ4WhcNMTQw
+MTA2MTg0MTQ4WjBRMRMwEQYKCZImiZPyLGQBGRYDbmV0MRowGAYKCZImiZPyLGQB
+GRYKc2hpYmJvbGV0aDEeMBwGA1UEAxMVaXNzdWVzLnNoaWJib2xldGgubmV0MIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtb4jIloWGvHJsSeq0PMjkWDA
++hseZ6/6/cEJKPk245f6hktC2k3z0AqJL8Kw9OudOjDx2op2jKm45TuIA46ti6VP
+f4stLIi7mO1B4A6jTWThCwU0DjMCwBXLhANdBQloyUYJU/usN8RBXlPnWZAV1dVb
+ygb7GUorkMON+wnFd7nhBePmQdJfbsqvKN8MykWfQ56chS+0lCYhyT7qql2bskJ4
+y621WSo47php2NyyU1KNcaFBLoao+UTH7KZ9qHOWJyGJGuWKwgZmCiVd0LQhWywP
+3M/JxZvpTr2Bs/J5d8BzZGSFUaHrVcPzIX+5c3sdK4d1wXUur1XE++bh9F9TjwID
+AQABoyEwHzAdBgNVHQ4EFgQUHtV8GWr64AIUV634b9YBlMEpHOwwDQYJKoZIhvcN
+AQEFBQADggEBAEzcImXrjUNZF/8AbpcDOqlBO/neTxE0Lcnv4HevHmjqVaemxXK5
+E2pAIJexcyCnp4EV7EK+5hpkr5J26iESHr3w4u/BvUvgSLNjlrIFw58mpBM9f+Qe
+q5bQWff+dmkhrxdhaIVraH70bsuxVKwycmUS0L11nOTxAQbh85wJbIwqH4fKAzQm
+jPp4VbLesRmUyDV+fY4YrZXHYosfuZLEexJgmgcRgZFug6NbWTclKnxKPhquYjem
+oHlA8E0OvkQswalMPLfSzhgftYNHohjdQ2oMBUC4uMk9T+r7ZeKkeCiXIzUzEh8M
+uQfWf/K4Fj4CqCzMOU3mmvy7ricwz/4Kzas=
+                           </ds:X509Certificate>
+                    </ds:X509Data>
+                </ds:KeyInfo>
+            </KeyDescriptor>            
+            <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/Artifact/SOAP" index="0"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SLO/Artifact"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SLO/POST"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.org/Shibboleth.sso/SLO/Redirect"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/SLO/SOAP"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://example.org/Shibboleth.sso/SAML/Artifact" index="0"/>
+
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://example.org/Shibboleth.sso/SAML/POST" index="1"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SAML2/Artifact" index="2"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
+            
+            <AttributeConsumingService index="1">
+                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+            </AttributeConsumingService>
+        </SPSSODescriptor>
+    <Organization>
+        <OrganizationName xml:lang="en">Ian A. Young</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">Ian A. Young</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">http://iay.org.uk/</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="support">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="technical">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="administrative">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ian@iay.org.uk</EmailAddress>
+    </ContactPerson>
+</EntityDescriptor>

--- a/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key.yaml
+++ b/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key.yaml
@@ -1,0 +1,4 @@
+expected:
+- status: error
+  component_id: check_saml2
+  message: "SAML 2.0 SP has no encryption key"

--- a/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key_and_no_cert.xml
+++ b/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key_and_no_cert.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test signing KeyDescriptor and no X509Data. Should fail as no encryption key found. -->
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:remd="http://refeds.org/metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+    xmlns:ukfedlabel="http://ukfederation.org.uk/2006/11/label"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd
+        urn:oasis:names:tc:SAML:metadata:algsupport sstc-saml-metadata-algsupport-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:attribute sstc-metadata-attr.xsd
+        urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:ui sstc-saml-metadata-ui-v1.0.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol sstc-saml-idp-discovery.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:request-init sstc-request-initiation.xsd
+        urn:oasis:names:tc:SAML:2.0:assertion saml-schema-assertion-2.0.xsd
+        urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd
+        http://ukfederation.org.uk/2006/11/label uk-fed-label.xsd
+        http://refeds.org/metadata refeds-metadata.xsd
+        http://www.w3.org/2001/04/xmlenc# xenc-schema.xsd
+        http://www.w3.org/2009/xmlenc11# xenc-schema-11.xsd
+        http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
+    ID="uk000006" entityID="http://idp2.iay.org.uk/idp/shibboleth">
+    <!--
+        This is an "Ian A. Young" IdP for Ian A. Young.
+    -->
+    <Extensions>
+        <ukfedlabel:UKFederationMember orgID="ukforg4590"/>
+        <shibmd:Scope regexp="false">iay.org.uk</shibmd:Scope>
+        <ukfedlabel:Software date="2016-11-17" fullVersion="3.3.0" name="Shibboleth" version="3"/>
+        <ukfedlabel:ExportOptIn date="2009-09-11"/>
+        <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+            registrationInstant="2007-03-30T16:36:00Z">
+            <mdrpi:RegistrationPolicy xml:lang="en"
+                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+        </mdrpi:RegistrationInfo>
+        <mdattr:EntityAttributes xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml:Attribute Name="http://macedir.org/entity-category-support"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>
+    </Extensions>
+     <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+            <Extensions>
+                <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://example.org/Shibboleth.sso/Login"/>
+                <idpdisc:DiscoveryResponse xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://example.org/Shibboleth.sso/Login" index="1"/>
+                <mdui:UIInfo>
+                    <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
+                </mdui:UIInfo>                
+            </Extensions>            
+            <KeyDescriptor use="signing">
+                <ds:KeyInfo>
+                    <ds:KeyName>example.org</ds:KeyName>
+                </ds:KeyInfo>
+            </KeyDescriptor>            
+            <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/Artifact/SOAP" index="0"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SLO/Artifact"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SLO/POST"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.org/Shibboleth.sso/SLO/Redirect"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/SLO/SOAP"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://example.org/Shibboleth.sso/SAML/Artifact" index="0"/>
+
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://example.org/Shibboleth.sso/SAML/POST" index="1"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SAML2/Artifact" index="2"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
+            
+            <AttributeConsumingService index="1">
+                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+            </AttributeConsumingService>
+        </SPSSODescriptor>
+    <Organization>
+        <OrganizationName xml:lang="en">Ian A. Young</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">Ian A. Young</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">http://iay.org.uk/</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="support">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="technical">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="administrative">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ian@iay.org.uk</EmailAddress>
+    </ContactPerson>
+</EntityDescriptor>

--- a/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key_and_no_cert.yaml
+++ b/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key_and_no_cert.yaml
@@ -1,0 +1,4 @@
+expected:
+- status: error
+  component_id: check_saml2
+  message: "SAML 2.0 SP has no encryption key"

--- a/tests/xml/saml2_enc_key/good_saml2_sp_enc_key_enc_use.xml
+++ b/tests/xml/saml2_enc_key/good_saml2_sp_enc_key_enc_use.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:remd="http://refeds.org/metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+    xmlns:ukfedlabel="http://ukfederation.org.uk/2006/11/label"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd
+        urn:oasis:names:tc:SAML:metadata:algsupport sstc-saml-metadata-algsupport-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:attribute sstc-metadata-attr.xsd
+        urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:ui sstc-saml-metadata-ui-v1.0.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol sstc-saml-idp-discovery.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:request-init sstc-request-initiation.xsd
+        urn:oasis:names:tc:SAML:2.0:assertion saml-schema-assertion-2.0.xsd
+        urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd
+        http://ukfederation.org.uk/2006/11/label uk-fed-label.xsd
+        http://refeds.org/metadata refeds-metadata.xsd
+        http://www.w3.org/2001/04/xmlenc# xenc-schema.xsd
+        http://www.w3.org/2009/xmlenc11# xenc-schema-11.xsd
+        http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
+    ID="uk000006" entityID="http://idp2.iay.org.uk/idp/shibboleth">
+    <!--
+        This is an "Ian A. Young" IdP for Ian A. Young.
+    -->
+    <Extensions>
+        <ukfedlabel:UKFederationMember orgID="ukforg4590"/>
+        <shibmd:Scope regexp="false">iay.org.uk</shibmd:Scope>
+        <ukfedlabel:Software date="2016-11-17" fullVersion="3.3.0" name="Shibboleth" version="3"/>
+        <ukfedlabel:ExportOptIn date="2009-09-11"/>
+        <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+            registrationInstant="2007-03-30T16:36:00Z">
+            <mdrpi:RegistrationPolicy xml:lang="en"
+                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+        </mdrpi:RegistrationInfo>
+        <mdattr:EntityAttributes xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml:Attribute Name="http://macedir.org/entity-category-support"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>
+    </Extensions>
+     <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+            <Extensions>
+                <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://example.org/Shibboleth.sso/Login"/>
+                <idpdisc:DiscoveryResponse xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://example.org/Shibboleth.sso/Login" index="1"/>
+                <mdui:UIInfo>
+                    <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
+                </mdui:UIInfo>                
+            </Extensions>            
+            <KeyDescriptor>
+                <ds:KeyInfo use="encryption">
+                    <ds:KeyName>example.org</ds:KeyName>
+                    <ds:X509Data>
+                        <ds:X509SubjectName>CN=example.org,DC=example,DC=org</ds:X509SubjectName>
+                        <ds:X509Certificate>
+MIIDRjCCAi6gAwIBAgIJAPpEsjMpUtq9MA0GCSqGSIb3DQEBBQUAMFExEzARBgoJ
+kiaJk/IsZAEZFgNuZXQxGjAYBgoJkiaJk/IsZAEZFgpzaGliYm9sZXRoMR4wHAYD
+VQQDExVpc3N1ZXMuc2hpYmJvbGV0aC5uZXQwHhcNMTEwMTA3MTg0MTQ4WhcNMTQw
+MTA2MTg0MTQ4WjBRMRMwEQYKCZImiZPyLGQBGRYDbmV0MRowGAYKCZImiZPyLGQB
+GRYKc2hpYmJvbGV0aDEeMBwGA1UEAxMVaXNzdWVzLnNoaWJib2xldGgubmV0MIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtb4jIloWGvHJsSeq0PMjkWDA
++hseZ6/6/cEJKPk245f6hktC2k3z0AqJL8Kw9OudOjDx2op2jKm45TuIA46ti6VP
+f4stLIi7mO1B4A6jTWThCwU0DjMCwBXLhANdBQloyUYJU/usN8RBXlPnWZAV1dVb
+ygb7GUorkMON+wnFd7nhBePmQdJfbsqvKN8MykWfQ56chS+0lCYhyT7qql2bskJ4
+y621WSo47php2NyyU1KNcaFBLoao+UTH7KZ9qHOWJyGJGuWKwgZmCiVd0LQhWywP
+3M/JxZvpTr2Bs/J5d8BzZGSFUaHrVcPzIX+5c3sdK4d1wXUur1XE++bh9F9TjwID
+AQABoyEwHzAdBgNVHQ4EFgQUHtV8GWr64AIUV634b9YBlMEpHOwwDQYJKoZIhvcN
+AQEFBQADggEBAEzcImXrjUNZF/8AbpcDOqlBO/neTxE0Lcnv4HevHmjqVaemxXK5
+E2pAIJexcyCnp4EV7EK+5hpkr5J26iESHr3w4u/BvUvgSLNjlrIFw58mpBM9f+Qe
+q5bQWff+dmkhrxdhaIVraH70bsuxVKwycmUS0L11nOTxAQbh85wJbIwqH4fKAzQm
+jPp4VbLesRmUyDV+fY4YrZXHYosfuZLEexJgmgcRgZFug6NbWTclKnxKPhquYjem
+oHlA8E0OvkQswalMPLfSzhgftYNHohjdQ2oMBUC4uMk9T+r7ZeKkeCiXIzUzEh8M
+uQfWf/K4Fj4CqCzMOU3mmvy7ricwz/4Kzas=
+                           </ds:X509Certificate>
+                    </ds:X509Data>
+                </ds:KeyInfo>
+            </KeyDescriptor>            
+            <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/Artifact/SOAP" index="0"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SLO/Artifact"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SLO/POST"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.org/Shibboleth.sso/SLO/Redirect"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/SLO/SOAP"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://example.org/Shibboleth.sso/SAML/Artifact" index="0"/>
+
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://example.org/Shibboleth.sso/SAML/POST" index="1"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SAML2/Artifact" index="2"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
+            
+            <AttributeConsumingService index="1">
+                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+            </AttributeConsumingService>
+        </SPSSODescriptor>
+    <Organization>
+        <OrganizationName xml:lang="en">Ian A. Young</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">Ian A. Young</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">http://iay.org.uk/</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="support">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="technical">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="administrative">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ian@iay.org.uk</EmailAddress>
+    </ContactPerson>
+</EntityDescriptor>

--- a/tests/xml/saml2_enc_key/good_saml2_sp_enc_key_no_use.xml
+++ b/tests/xml/saml2_enc_key/good_saml2_sp_enc_key_no_use.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:remd="http://refeds.org/metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+    xmlns:ukfedlabel="http://ukfederation.org.uk/2006/11/label"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd
+        urn:oasis:names:tc:SAML:metadata:algsupport sstc-saml-metadata-algsupport-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:attribute sstc-metadata-attr.xsd
+        urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:ui sstc-saml-metadata-ui-v1.0.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol sstc-saml-idp-discovery.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:request-init sstc-request-initiation.xsd
+        urn:oasis:names:tc:SAML:2.0:assertion saml-schema-assertion-2.0.xsd
+        urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd
+        http://ukfederation.org.uk/2006/11/label uk-fed-label.xsd
+        http://refeds.org/metadata refeds-metadata.xsd
+        http://www.w3.org/2001/04/xmlenc# xenc-schema.xsd
+        http://www.w3.org/2009/xmlenc11# xenc-schema-11.xsd
+        http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
+    ID="uk000006" entityID="http://idp2.iay.org.uk/idp/shibboleth">
+    <!--
+        This is an "Ian A. Young" IdP for Ian A. Young.
+    -->
+    <Extensions>
+        <ukfedlabel:UKFederationMember orgID="ukforg4590"/>
+        <shibmd:Scope regexp="false">iay.org.uk</shibmd:Scope>
+        <ukfedlabel:Software date="2016-11-17" fullVersion="3.3.0" name="Shibboleth" version="3"/>
+        <ukfedlabel:ExportOptIn date="2009-09-11"/>
+        <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+            registrationInstant="2007-03-30T16:36:00Z">
+            <mdrpi:RegistrationPolicy xml:lang="en"
+                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+        </mdrpi:RegistrationInfo>
+        <mdattr:EntityAttributes xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml:Attribute Name="http://macedir.org/entity-category-support"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>
+    </Extensions>
+     <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+            <Extensions>
+                <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://example.org/Shibboleth.sso/Login"/>
+                <idpdisc:DiscoveryResponse xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://example.org/Shibboleth.sso/Login" index="1"/>
+                <mdui:UIInfo>
+                    <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
+                </mdui:UIInfo>                
+            </Extensions>            
+            <KeyDescriptor>
+                <ds:KeyInfo>
+                    <ds:KeyName>example.org</ds:KeyName>
+                    <ds:X509Data>
+                        <ds:X509SubjectName>CN=example.org,DC=example,DC=org</ds:X509SubjectName>
+                        <ds:X509Certificate>
+MIIDRjCCAi6gAwIBAgIJAPpEsjMpUtq9MA0GCSqGSIb3DQEBBQUAMFExEzARBgoJ
+kiaJk/IsZAEZFgNuZXQxGjAYBgoJkiaJk/IsZAEZFgpzaGliYm9sZXRoMR4wHAYD
+VQQDExVpc3N1ZXMuc2hpYmJvbGV0aC5uZXQwHhcNMTEwMTA3MTg0MTQ4WhcNMTQw
+MTA2MTg0MTQ4WjBRMRMwEQYKCZImiZPyLGQBGRYDbmV0MRowGAYKCZImiZPyLGQB
+GRYKc2hpYmJvbGV0aDEeMBwGA1UEAxMVaXNzdWVzLnNoaWJib2xldGgubmV0MIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtb4jIloWGvHJsSeq0PMjkWDA
++hseZ6/6/cEJKPk245f6hktC2k3z0AqJL8Kw9OudOjDx2op2jKm45TuIA46ti6VP
+f4stLIi7mO1B4A6jTWThCwU0DjMCwBXLhANdBQloyUYJU/usN8RBXlPnWZAV1dVb
+ygb7GUorkMON+wnFd7nhBePmQdJfbsqvKN8MykWfQ56chS+0lCYhyT7qql2bskJ4
+y621WSo47php2NyyU1KNcaFBLoao+UTH7KZ9qHOWJyGJGuWKwgZmCiVd0LQhWywP
+3M/JxZvpTr2Bs/J5d8BzZGSFUaHrVcPzIX+5c3sdK4d1wXUur1XE++bh9F9TjwID
+AQABoyEwHzAdBgNVHQ4EFgQUHtV8GWr64AIUV634b9YBlMEpHOwwDQYJKoZIhvcN
+AQEFBQADggEBAEzcImXrjUNZF/8AbpcDOqlBO/neTxE0Lcnv4HevHmjqVaemxXK5
+E2pAIJexcyCnp4EV7EK+5hpkr5J26iESHr3w4u/BvUvgSLNjlrIFw58mpBM9f+Qe
+q5bQWff+dmkhrxdhaIVraH70bsuxVKwycmUS0L11nOTxAQbh85wJbIwqH4fKAzQm
+jPp4VbLesRmUyDV+fY4YrZXHYosfuZLEexJgmgcRgZFug6NbWTclKnxKPhquYjem
+oHlA8E0OvkQswalMPLfSzhgftYNHohjdQ2oMBUC4uMk9T+r7ZeKkeCiXIzUzEh8M
+uQfWf/K4Fj4CqCzMOU3mmvy7ricwz/4Kzas=
+                           </ds:X509Certificate>
+                    </ds:X509Data>
+                </ds:KeyInfo>
+            </KeyDescriptor>            
+            <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/Artifact/SOAP" index="0"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SLO/Artifact"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SLO/POST"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.org/Shibboleth.sso/SLO/Redirect"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.org/Shibboleth.sso/SLO/SOAP"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://example.org/Shibboleth.sso/SAML/Artifact" index="0"/>
+
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://example.org/Shibboleth.sso/SAML/POST" index="1"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.org/Shibboleth.sso/SAML2/Artifact" index="2"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
+            
+            <AttributeConsumingService index="1">
+                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+            </AttributeConsumingService>
+        </SPSSODescriptor>
+    <Organization>
+        <OrganizationName xml:lang="en">Ian A. Young</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">Ian A. Young</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">http://iay.org.uk/</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="support">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="technical">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ukfed+fc2ee77e@iay.org.uk</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="administrative">
+        <GivenName>Ian</GivenName>
+        <SurName>Young</SurName>
+        <EmailAddress>mailto:ian@iay.org.uk</EmailAddress>
+    </ContactPerson>
+</EntityDescriptor>

--- a/validators/overlays/all/classes/_rules/check_saml2.xsl
+++ b/validators/overlays/all/classes/_rules/check_saml2.xsl
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    check_saml2.xsl
+
+    Checking ruleset containing rules associated with the SAML 2.0 specification.
+
+    Author: Ian A. Young <ian@iay.org.uk>
+
+-->
+<xsl:stylesheet version="1.0"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+
+    <!--
+        Common support functions.
+    -->
+    <xsl:import href="check_framework.xsl"/>
+
+
+    <!--
+        It does not make sense for an IdP to have more than one SingleSignOnService
+        with any of a list of SAML 2.0 front-channel bindings.
+    -->
+    <xsl:template match="md:SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'][position()>1]">
+        <xsl:call-template name="error">
+            <xsl:with-param name="m">more than one SingleSignOnService with SAML 2.0 HTTP-POST binding</xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+    <xsl:template match="md:SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign'][position()>1]">
+        <xsl:call-template name="error">
+            <xsl:with-param name="m">more than one SingleSignOnService with SAML 2.0 HTTP-POST-SimpleSign binding</xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+    <xsl:template match="md:SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'][position()>1]">
+        <xsl:call-template name="error">
+            <xsl:with-param name="m">more than one SingleSignOnService with SAML 2.0 HTTP-Redirect binding</xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!--
+        A SAML 2.0 IdP with an AttributeAuthority needs an AttributeService with an appropriate Binding.
+    -->
+    <xsl:template match="md:AttributeAuthorityDescriptor
+        [contains(@protocolSupportEnumeration, 'urn:oasis:names:tc:SAML:2.0:protocol')]
+        [not(md:AttributeService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:SOAP'])]
+        ">
+        <xsl:call-template name="error">
+            <xsl:with-param name="m">SAML 2.0 AttributeAuthority missing appropriately bound AttributeService</xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+
+    <!--
+        Check for SAML 2.0 SPs which lack an encryption key.
+    -->
+    <xsl:template match="md:SPSSODescriptor
+        [contains(@protocolSupportEnumeration, 'urn:oasis:names:tc:SAML:2.0:protocol')]
+        [not((md:KeyDescriptor[descendant::ds:X509Data and @use='encryption']) or ((md:KeyDescriptor[descendant::ds:X509Data and not(@use)])))]">
+        <xsl:call-template name="error">
+            <xsl:with-param name="m">SAML 2.0 SP has no encryption key</xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!--
+        Use of SAML 2.0 bindings requires SAML 2.0 in protocolSupportEnumeration.
+    -->
+    <xsl:template match="md:IDPSSODescriptor
+        [not(contains(@protocolSupportEnumeration, 'urn:oasis:names:tc:SAML:2.0:protocol'))]
+        [md:*/@Binding[starts-with(., 'urn:oasis:names:tc:SAML:2.0:bindings:')]]">
+        <xsl:call-template name="error">
+            <xsl:with-param name="m">
+                <xsl:text>SAML 2.0 binding requires SAML 2.0 token in IDPSSODescriptor/@protocolSupportEnumeration</xsl:text>
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!--
+        Use of SAML 2.0 bindings requires SAML 2.0 in protocolSupportEnumeration.
+    -->
+    <xsl:template match="md:AttributeAuthorityDescriptor
+        [not(contains(@protocolSupportEnumeration, 'urn:oasis:names:tc:SAML:2.0:protocol'))]
+        [md:*/@Binding[starts-with(., 'urn:oasis:names:tc:SAML:2.0:bindings:')]]">
+        <xsl:call-template name="error">
+            <xsl:with-param name="m">
+                <xsl:text>SAML 2.0 binding requires SAML 2.0 token in AttributeAuthorityDescriptor/@protocolSupportEnumeration</xsl:text>
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!--
+        Use of SAML 2.0 bindings requires SAML 2.0 in protocolSupportEnumeration.
+    -->
+    <xsl:template match="md:SPSSODescriptor
+        [not(contains(@protocolSupportEnumeration, 'urn:oasis:names:tc:SAML:2.0:protocol'))]
+        [md:*/@Binding[starts-with(., 'urn:oasis:names:tc:SAML:2.0:bindings:')]]">
+        <xsl:call-template name="error">
+            <xsl:with-param name="m">
+                <xsl:text>SAML 2.0 binding requires SAML 2.0 token in SPSSODescriptor/@protocolSupportEnumeration</xsl:text>
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/validators/overlays/all/classes/default-validator-stages.xml
+++ b/validators/overlays/all/classes/default-validator-stages.xml
@@ -10,6 +10,7 @@
     <!-- The list of tests (stages) used by the default validator -->
     <util:list id="default_validator_stages">
        <ref bean="check_entityid_prefix"/>
+       <ref bean="check_saml2"/>
     </util:list>
 
 </beans>

--- a/validators/overlays/all/classes/default-validator.xml
+++ b/validators/overlays/all/classes/default-validator.xml
@@ -21,6 +21,12 @@
     <bean id="check_entityid_prefix" parent="mda.XSLValidationStage"
         p:XSLResource="classpath:_rules/check_entityid_prefix.xsl"/>
 
+    <!--
+        check_saml2
+    -->
+    <bean id="check_saml2" parent="mda.XSLValidationStage"
+        p:XSLResource="classpath:_rules/check_saml2.xsl"/>
+
     <bean id="pipeline" parent="mda.SimplePipeline">
         <property name="stages" ref="default_validator_stages"/>
     </bean>


### PR DESCRIPTION
 - Fix predicates in check_saml2.xsl to be compatible with the JDK native XSLT processor
 - Add tests for SAML 2.0 SPs with encryption keys
 - Add tests for SAML 2.0 SPs without encryption keys

See also ukfederation#383