### PR TITLE
Check for schema validity as part of cross-ruleset validity of test data

### DIFF
--- a/tests/xml/mdrpi/bad_mdrpi_misspelled_pubinfo.xml
+++ b/tests/xml/mdrpi/bad_mdrpi_misspelled_pubinfo.xml
@@ -48,6 +48,56 @@
             </saml:Attribute>
         </mdattr:EntityAttributes>
     </Extensions>
+    <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>       
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
         <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>

--- a/tests/xml/mdrpi/bad_pubinfo_outside_extensions.xml
+++ b/tests/xml/mdrpi/bad_pubinfo_outside_extensions.xml
@@ -28,8 +28,6 @@
         http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
     ID="uk999999" entityID="https://idp.example.org/idp/shibboleth">
 
-    <!-- Should be inside extensions -->
-    <mdrpi:PublicationInfo creationInstant="2017-08-16T19:10:29Z" publisher="http://ukfederation.org.uk"/>
     <Extensions>
         <ukfedlabel:UKFederationMember orgID="ukforg9999"/>
         <shibmd:Scope regexp="false">example.org</shibmd:Scope>
@@ -48,6 +46,60 @@
             </saml:Attribute>
         </mdattr:EntityAttributes>
     </Extensions>
+   
+     <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO">
+             <!-- Should be inside extensions. EndpointType is one of the only other extensible places to put it that is schema valid -->
+            <mdrpi:PublicationInfo creationInstant="2017-08-16T19:10:29Z" publisher="http://ukfederation.org.uk"/>
+        </SingleSignOnService>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>       
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
         <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>

--- a/tests/xml/mdrpi/bad_pubinfo_outside_extensions.yaml
+++ b/tests/xml/mdrpi/bad_pubinfo_outside_extensions.yaml
@@ -1,4 +1,4 @@
 expected:
-- status: error
-  component_id: check_mdrpi_xslt
-  message: "PublicationInfo must only appear within an Extensions element"
+  - status: error
+    component_id: check_mdrpi_xslt
+    message: PublicationInfo must only appear within an Extensions element

--- a/tests/xml/mdrpi/bad_reginfo_no_unique_lang.xml
+++ b/tests/xml/mdrpi/bad_reginfo_no_unique_lang.xml
@@ -47,6 +47,56 @@
             </saml:Attribute>
         </mdattr:EntityAttributes>
     </Extensions>
+     <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>       
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
         <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>

--- a/tests/xml/mdrpi/bad_reginfo_no_utc_time.xml
+++ b/tests/xml/mdrpi/bad_reginfo_no_utc_time.xml
@@ -46,6 +46,56 @@
             </saml:Attribute>
         </mdattr:EntityAttributes>
     </Extensions>
+     <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>       
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
         <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>

--- a/tests/xml/mdrpi/bad_reginfo_outside_extensions.xml
+++ b/tests/xml/mdrpi/bad_reginfo_outside_extensions.xml
@@ -28,11 +28,6 @@
         http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
     ID="uk999999" entityID="https://idp.example.org/idp/shibboleth">
 
-    <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
-            registrationInstant="2007-03-30T16:36:00Z">
-            <mdrpi:RegistrationPolicy xml:lang="en"
-                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
-    </mdrpi:RegistrationInfo>
     <Extensions>
         <ukfedlabel:UKFederationMember orgID="ukforg9999"/>
         <shibmd:Scope regexp="false">example.org</shibmd:Scope>
@@ -49,7 +44,64 @@
                 <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
             </saml:Attribute>
         </mdattr:EntityAttributes>
-    </Extensions>
+    </Extensions>    
+     <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO">
+             <!-- Outside of extensions. EndpointType is one of the only other extensible places to put it that is schema valid -->
+            <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+                registrationInstant="2007-03-30T16:36:00Z">
+                <mdrpi:RegistrationPolicy xml:lang="en"
+                 >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+    </mdrpi:RegistrationInfo>
+        </SingleSignOnService>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>       
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
         <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>

--- a/tests/xml/mdrpi/bad_reginfo_outside_extensions.yaml
+++ b/tests/xml/mdrpi/bad_reginfo_outside_extensions.yaml
@@ -1,4 +1,4 @@
 expected:
-- status: error
-  component_id: check_mdrpi_xslt
-  message: "RegistrationInfo must only appear within an Extensions element"
+  - status: error
+    component_id: check_mdrpi_xslt
+    message: RegistrationInfo must only appear within an Extensions element

--- a/tests/xml/mdrpi/bad_two_pubinfo.xml
+++ b/tests/xml/mdrpi/bad_two_pubinfo.xml
@@ -49,6 +49,56 @@
             </saml:Attribute>
         </mdattr:EntityAttributes>
     </Extensions>
+     <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>       
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
         <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>

--- a/tests/xml/mdrpi/bad_two_reginfo.xml
+++ b/tests/xml/mdrpi/bad_two_reginfo.xml
@@ -51,6 +51,56 @@
             </saml:Attribute>
         </mdattr:EntityAttributes>
     </Extensions>
+     <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>       
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
         <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>

--- a/tests/xml/mdrpi/good_mdrpi.xml
+++ b/tests/xml/mdrpi/good_mdrpi.xml
@@ -46,6 +46,56 @@
             </saml:Attribute>
         </mdattr:EntityAttributes>
     </Extensions>
+     <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>       
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
         <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>

--- a/tests/xml/saml2_attr_authority_bindings/bad_saml2_bindings_no_protocol_enum.xml
+++ b/tests/xml/saml2_attr_authority_bindings/bad_saml2_bindings_no_protocol_enum.xml
@@ -115,7 +115,7 @@
         <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
             Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
     </IDPSSODescriptor>
-    <AttributeAuthorityDescriptor>
+    <AttributeAuthorityDescriptor protocolSupportEnumeration="">
         <KeyDescriptor>
             <ds:KeyInfo>
                 <ds:X509Data>

--- a/tests/xml/saml2_enc_key/bad_saml2_sp_enc_key_no_cert.xml
+++ b/tests/xml/saml2_enc_key/bad_saml2_sp_enc_key_no_cert.xml
@@ -71,12 +71,6 @@
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
-            
-            <AttributeConsumingService index="1">
-                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
-                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-            </AttributeConsumingService>
         </SPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>

--- a/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key.xml
+++ b/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key.xml
@@ -94,12 +94,6 @@
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
-            
-            <AttributeConsumingService index="1">
-                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
-                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-            </AttributeConsumingService>
         </SPSSODescriptor>
    <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>

--- a/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key_and_no_cert.xml
+++ b/tests/xml/saml2_enc_key/bad_saml2_sp_no_enc_key_sig_key_and_no_cert.xml
@@ -71,12 +71,6 @@
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
-            
-            <AttributeConsumingService index="1">
-                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
-                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-            </AttributeConsumingService>
         </SPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>

--- a/tests/xml/saml2_enc_key/good_saml2_sp_enc_key_enc_use.xml
+++ b/tests/xml/saml2_enc_key/good_saml2_sp_enc_key_enc_use.xml
@@ -53,8 +53,8 @@
                     <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
                 </mdui:UIInfo>                
             </Extensions>            
-            <KeyDescriptor>
-                <ds:KeyInfo use="encryption">
+            <KeyDescriptor use="encryption">
+                <ds:KeyInfo>
                     <ds:KeyName>example.org</ds:KeyName>
                     <ds:X509Data>
                         <ds:X509SubjectName>CN=example.org,DC=example,DC=org</ds:X509SubjectName>
@@ -93,12 +93,6 @@
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
-            
-            <AttributeConsumingService index="1">
-                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
-                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-            </AttributeConsumingService>
         </SPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>

--- a/tests/xml/saml2_enc_key/good_saml2_sp_enc_key_no_use.xml
+++ b/tests/xml/saml2_enc_key/good_saml2_sp_enc_key_no_use.xml
@@ -93,12 +93,6 @@
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.org/Shibboleth.sso/SAML2/POST" index="4"/>
             <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
-            
-            <AttributeConsumingService index="1">
-                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
-                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
-            </AttributeConsumingService>
         </SPSSODescriptor>
    <Organization>
         <OrganizationName xml:lang="en">An Example Organization</OrganizationName>

--- a/tests/xml/saml2_idp_bindings/bad_saml2_bindings_no_protocol_enum.xml
+++ b/tests/xml/saml2_idp_bindings/bad_saml2_bindings_no_protocol_enum.xml
@@ -45,7 +45,7 @@
             </saml:Attribute>
         </mdattr:EntityAttributes>
     </Extensions>
-    <IDPSSODescriptor>
+    <IDPSSODescriptor protocolSupportEnumeration="">
         <Extensions>
             <mdui:UIInfo>
                 <mdui:DisplayName xml:lang="en">An Example Entity</mdui:DisplayName>

--- a/tests/xml/saml2_sp_bindings/bad_saml2_bindings_no_protocol_enum.xml
+++ b/tests/xml/saml2_sp_bindings/bad_saml2_bindings_no_protocol_enum.xml
@@ -45,7 +45,7 @@
             </saml:Attribute>
         </mdattr:EntityAttributes>
     </Extensions>
-    <SPSSODescriptor>
+    <SPSSODescriptor protocolSupportEnumeration="">
             <Extensions>
                 <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://sp.example.org/Shibboleth.sso/Login"/>
                 <idpdisc:DiscoveryResponse xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://sp.example.org/Shibboleth.sso/Login" index="1"/>
@@ -53,8 +53,8 @@
                     <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
                 </mdui:UIInfo>                
             </Extensions>            
-            <KeyDescriptor>
-                <ds:KeyInfo use="encryption">
+            <KeyDescriptor use="encryption">
+                <ds:KeyInfo>
                     <ds:KeyName>example.org</ds:KeyName>
                     <ds:X509Data>
                         <ds:X509SubjectName>CN=example.org,DC=example,DC=org</ds:X509SubjectName>

--- a/tests/xml/saml2_sp_bindings/bad_saml2_bindings_wrong_protocol_enum.xml
+++ b/tests/xml/saml2_sp_bindings/bad_saml2_bindings_wrong_protocol_enum.xml
@@ -53,8 +53,8 @@
                     <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
                 </mdui:UIInfo>                
             </Extensions>            
-            <KeyDescriptor>
-                <ds:KeyInfo use="encryption">
+            <KeyDescriptor use="encryption">
+                <ds:KeyInfo>
                     <ds:KeyName>example.org</ds:KeyName>
                     <ds:X509Data>
                         <ds:X509SubjectName>CN=example.org,DC=example,DC=org</ds:X509SubjectName>

--- a/tests/xml/saml2_sp_bindings/good_saml2_bindings_protocol_enum.xml
+++ b/tests/xml/saml2_sp_bindings/good_saml2_bindings_protocol_enum.xml
@@ -53,8 +53,8 @@
                     <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
                 </mdui:UIInfo>                
             </Extensions>            
-            <KeyDescriptor>
-                <ds:KeyInfo use="encryption">
+            <KeyDescriptor use="encryption">
+                <ds:KeyInfo>
                     <ds:KeyName>example.org</ds:KeyName>
                     <ds:X509Data>
                         <ds:X509SubjectName>CN=example.org,DC=example,DC=org</ds:X509SubjectName>

--- a/tests/xml/saml2_sp_bindings/good_saml2_no_bindings_protocol_enum.xml
+++ b/tests/xml/saml2_sp_bindings/good_saml2_no_bindings_protocol_enum.xml
@@ -53,8 +53,8 @@
                     <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
                 </mdui:UIInfo>                
             </Extensions>            
-            <KeyDescriptor>
-                <ds:KeyInfo use="encryption">
+            <KeyDescriptor use="encryption">
+                <ds:KeyInfo>
                     <ds:KeyName>example.org</ds:KeyName>
                     <ds:X509Data>
                         <ds:X509SubjectName>CN=example.org,DC=example,DC=org</ds:X509SubjectName>
@@ -93,8 +93,20 @@
                            </ds:X509Certificate>
                     </ds:X509Data>
                 </ds:KeyInfo>
-            </KeyDescriptor>            
-          </SPSSODescriptor>
+            </KeyDescriptor>  
+            <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sp.example.org/Shibboleth.sso/Artifact/SOAP" index="0"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sp.example.org/Shibboleth.sso/SLO/Artifact"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.example.org/Shibboleth.sso/SLO/POST"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp.example.org/Shibboleth.sso/SLO/Redirect"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sp.example.org/Shibboleth.sso/SLO/SOAP"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://sp.example.org/Shibboleth.sso/SAML/Artifact" index="0"/>
+
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://sp.example.org/Shibboleth.sso/SAML/POST" index="1"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sp.example.org/Shibboleth.sso/SAML2/Artifact" index="2"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://sp.example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.example.org/Shibboleth.sso/SAML2/POST" index="4"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://sp.example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>  
+    </SPSSODescriptor>
     <Organization>
         <OrganizationName xml:lang="en">An Example Entity</OrganizationName>
         <OrganizationDisplayName xml:lang="en">An Example Entity</OrganizationDisplayName>

--- a/tests/xml/schema/bad_schema_invalid_no_roles.xml
+++ b/tests/xml/schema/bad_schema_invalid_no_roles.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:remd="http://refeds.org/metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+    xmlns:ukfedlabel="http://ukfederation.org.uk/2006/11/label"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd
+        urn:oasis:names:tc:SAML:metadata:algsupport sstc-saml-metadata-algsupport-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:attribute sstc-metadata-attr.xsd
+        urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:ui sstc-saml-metadata-ui-v1.0.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol sstc-saml-idp-discovery.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:request-init sstc-request-initiation.xsd
+        urn:oasis:names:tc:SAML:2.0:assertion saml-schema-assertion-2.0.xsd
+        urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd
+        http://ukfederation.org.uk/2006/11/label uk-fed-label.xsd
+        http://refeds.org/metadata refeds-metadata.xsd
+        http://www.w3.org/2001/04/xmlenc# xenc-schema.xsd
+        http://www.w3.org/2009/xmlenc11# xenc-schema-11.xsd
+        http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
+    ID="uk999999" entityID="https://idp.example.org/idp/shibboleth">
+
+    <Extensions>
+        <ukfedlabel:UKFederationMember orgID="ukforg9999"/>
+        <shibmd:Scope regexp="false">example.org</shibmd:Scope>
+        <ukfedlabel:Software date="2016-11-17" fullVersion="3.3.0" name="Shibboleth" version="3"/>
+        <ukfedlabel:ExportOptIn date="2009-09-11"/>
+        <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+            registrationInstant="2007-03-30T16:36:00Z">
+            <mdrpi:RegistrationPolicy xml:lang="en"
+                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+        </mdrpi:RegistrationInfo>
+        <mdrpi:PublicationInfo creationInstant="2017-08-16T19:10:29Z" publisher="http://ukfederation.org.uk"/>
+        <mdattr:EntityAttributes xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml:Attribute Name="http://macedir.org/entity-category-support"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>
+    </Extensions>
+    <Organization>
+        <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">http://example.org/</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="support">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:ukfed@example.org</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="technical">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:ukfed@example.org</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="administrative">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:anexample@example.org</EmailAddress>
+    </ContactPerson>
+</EntityDescriptor>

--- a/tests/xml/schema/bad_schema_invalid_no_roles.yaml
+++ b/tests/xml/schema/bad_schema_invalid_no_roles.yaml
@@ -1,0 +1,9 @@
+expected:
+- status: error
+  component_id: checkSchemas
+  message: 'cvc-complex-type.2.4.a: Invalid content was found starting with element
+    ''{"urn:oasis:names:tc:SAML:2.0:metadata":Organization}''. One of ''{"urn:oasis:names:tc:SAML:2.0:metadata":RoleDescriptor,
+    "urn:oasis:names:tc:SAML:2.0:metadata":IDPSSODescriptor, "urn:oasis:names:tc:SAML:2.0:metadata":SPSSODescriptor,
+    "urn:oasis:names:tc:SAML:2.0:metadata":AuthnAuthorityDescriptor, "urn:oasis:names:tc:SAML:2.0:metadata":AttributeAuthorityDescriptor,
+    "urn:oasis:names:tc:SAML:2.0:metadata":PDPDescriptor, "urn:oasis:names:tc:SAML:2.0:metadata":AffiliationDescriptor}''
+    is expected.'

--- a/tests/xml/schema/good_schema_valid.xml
+++ b/tests/xml/schema/good_schema_valid.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:remd="http://refeds.org/metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+    xmlns:ukfedlabel="http://ukfederation.org.uk/2006/11/label"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd
+        urn:oasis:names:tc:SAML:metadata:algsupport sstc-saml-metadata-algsupport-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:attribute sstc-metadata-attr.xsd
+        urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:ui sstc-saml-metadata-ui-v1.0.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol sstc-saml-idp-discovery.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:request-init sstc-request-initiation.xsd
+        urn:oasis:names:tc:SAML:2.0:assertion saml-schema-assertion-2.0.xsd
+        urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd
+        http://ukfederation.org.uk/2006/11/label uk-fed-label.xsd
+        http://refeds.org/metadata refeds-metadata.xsd
+        http://www.w3.org/2001/04/xmlenc# xenc-schema.xsd
+        http://www.w3.org/2009/xmlenc11# xenc-schema-11.xsd
+        http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
+    ID="uk999999" entityID="https://idp.example.org/idp/shibboleth">
+
+    <Extensions>
+        <ukfedlabel:UKFederationMember orgID="ukforg9999"/>
+        <shibmd:Scope regexp="false">example.org</shibmd:Scope>
+        <ukfedlabel:Software date="2016-11-17" fullVersion="3.3.0" name="Shibboleth" version="3"/>
+        <ukfedlabel:ExportOptIn date="2009-09-11"/>
+        <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+            registrationInstant="2007-03-30T16:36:00Z">
+            <mdrpi:RegistrationPolicy xml:lang="en"
+                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+        </mdrpi:RegistrationInfo>
+        <mdrpi:PublicationInfo creationInstant="2017-08-16T19:10:29Z" publisher="http://ukfederation.org.uk"/>
+        <mdattr:EntityAttributes xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml:Attribute Name="http://macedir.org/entity-category-support"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>
+    </Extensions>
+     <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>       
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
+    <Organization>
+        <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">http://example.org/</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="support">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:ukfed@example.org</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="technical">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:ukfed@example.org</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="administrative">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:anexample@example.org</EmailAddress>
+    </ContactPerson>
+</EntityDescriptor>

--- a/validators/overlays/all/classes/default-validator-stages.xml
+++ b/validators/overlays/all/classes/default-validator-stages.xml
@@ -9,6 +9,7 @@
 
     <!-- The list of tests (stages) used by the default validator -->
     <util:list id="default_validator_stages">
+       <ref bean="checkSchemas"/>
        <ref bean="check_entityid_prefix"/>
        <ref bean="check_saml2"/>
        <ref bean="check_mdrpi_xslt"/>


### PR DESCRIPTION
1. Enable schema checking — lots of failures.
2. Clean up existing test cases to be schema valid.
   a. See note below. 
4. Add tests for the schema validation stage.

This fixes #13.

**Note**: For the rule '_RegistrationInfo must only appear within an Extensions element_' and '_PublicationInfo must only appear within an Extensions element'_ I placed them inside a `<SingleSignOnService>` element, as the `EndpointType` was the only other place I could see that would allow them (sequence of `any`) whilst still being schema valid that would trigger that error.