### PR TITLE
Add tests for CoCo v2 support

### DIFF
--- a/tests/xml/check_coco_v2_support/bad_coco_v2_support_on_sp.xml
+++ b/tests/xml/check_coco_v2_support/bad_coco_v2_support_on_sp.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:remd="http://refeds.org/metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+    xmlns:ukfedlabel="http://ukfederation.org.uk/2006/11/label"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd
+        urn:oasis:names:tc:SAML:metadata:algsupport sstc-saml-metadata-algsupport-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:attribute sstc-metadata-attr.xsd
+        urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:ui sstc-saml-metadata-ui-v1.0.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol sstc-saml-idp-discovery.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:request-init sstc-request-initiation.xsd
+        urn:oasis:names:tc:SAML:2.0:assertion saml-schema-assertion-2.0.xsd
+        urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd
+        http://ukfederation.org.uk/2006/11/label uk-fed-label.xsd
+        http://refeds.org/metadata refeds-metadata.xsd
+        http://www.w3.org/2001/04/xmlenc# xenc-schema.xsd
+        http://www.w3.org/2009/xmlenc11# xenc-schema-11.xsd
+        http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
+    ID="uk999999" entityID="https://idp.example.org/idp/shibboleth">
+
+    <Extensions>
+        <ukfedlabel:UKFederationMember orgID="ukforg9999"/>
+        <shibmd:Scope regexp="false">example.org</shibmd:Scope>
+        <ukfedlabel:Software date="2016-11-17" fullVersion="3.3.0" name="Shibboleth" version="3"/>
+        <ukfedlabel:ExportOptIn date="2009-09-11"/>
+        <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+            registrationInstant="2007-03-30T16:36:00Z">
+            <mdrpi:RegistrationPolicy xml:lang="en"
+                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+        </mdrpi:RegistrationInfo>
+        <mdattr:EntityAttributes xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml:Attribute Name="http://macedir.org/entity-category-support"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>https://refeds.org/category/code-of-conduct/v2</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>   
+    </Extensions>
+    <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+            <Extensions>
+                <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://sp.example.org/Shibboleth.sso/Login"/>
+                <idpdisc:DiscoveryResponse xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://sp.example.org/Shibboleth.sso/Login" index="1"/>
+                <mdui:UIInfo>
+                    <mdui:DisplayName xml:lang="en">Test SPSSODescriptor</mdui:DisplayName>
+                </mdui:UIInfo>                
+            </Extensions>            
+            <KeyDescriptor use="encryption">
+                <ds:KeyInfo>
+                    <ds:KeyName>example.org</ds:KeyName>
+                    <ds:X509Data>
+                        <ds:X509SubjectName>CN=example.org,DC=example,DC=org</ds:X509SubjectName>
+                        <ds:X509Certificate>
+                            MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                            BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                            aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                            bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                            VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                            A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                            AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                            bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                            opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                            sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                            9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                            nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                            PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                            dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                            FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                            Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                            Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                            NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                            7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                            Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                            aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                            aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                            jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                            FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                            l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                            5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                            IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                            GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                            Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                            6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                            IrhKy4GrwvGT/y1q8Q==
+                           </ds:X509Certificate>
+                    </ds:X509Data>
+                </ds:KeyInfo>
+            </KeyDescriptor>            
+            <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sp.example.org/Shibboleth.sso/Artifact/SOAP" index="0"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sp.example.org/Shibboleth.sso/SLO/Artifact"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.example.org/Shibboleth.sso/SLO/POST"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp.example.org/Shibboleth.sso/SLO/Redirect"/>
+            <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sp.example.org/Shibboleth.sso/SLO/SOAP"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://sp.example.org/Shibboleth.sso/SAML/Artifact" index="0"/>
+
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://sp.example.org/Shibboleth.sso/SAML/POST" index="1"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sp.example.org/Shibboleth.sso/SAML2/Artifact" index="2"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://sp.example.org/Shibboleth.sso/SAML2/ECP" index="3"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.example.org/Shibboleth.sso/SAML2/POST" index="4"/>
+            <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" Location="https://sp.example.org/Shibboleth.sso/SAML2/POST-SimpleSign" index="5"/>
+        </SPSSODescriptor>
+    <Organization>
+        <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">http://example.org/</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="support">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:ukfed@example.org</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="technical">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:ukfed@example.org</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="administrative">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:anexample@example.org</EmailAddress>
+    </ContactPerson>
+</EntityDescriptor>

--- a/tests/xml/check_coco_v2_support/bad_coco_v2_support_on_sp.yaml
+++ b/tests/xml/check_coco_v2_support/bad_coco_v2_support_on_sp.yaml
@@ -1,0 +1,4 @@
+expected:
+- status: error
+  component_id: check_coco_v2_support
+  message: "REFEDS Data Protection Code of Conduct support only applies to identity provider entities"

--- a/tests/xml/check_coco_v2_support/good_coco_v2_support.xml
+++ b/tests/xml/check_coco_v2_support/good_coco_v2_support.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:remd="http://refeds.org/metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+    xmlns:ukfedlabel="http://ukfederation.org.uk/2006/11/label"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd
+        urn:oasis:names:tc:SAML:metadata:algsupport sstc-saml-metadata-algsupport-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:attribute sstc-metadata-attr.xsd
+        urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd
+        urn:oasis:names:tc:SAML:metadata:ui sstc-saml-metadata-ui-v1.0.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol sstc-saml-idp-discovery.xsd
+        urn:oasis:names:tc:SAML:profiles:SSO:request-init sstc-request-initiation.xsd
+        urn:oasis:names:tc:SAML:2.0:assertion saml-schema-assertion-2.0.xsd
+        urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd
+        http://ukfederation.org.uk/2006/11/label uk-fed-label.xsd
+        http://refeds.org/metadata refeds-metadata.xsd
+        http://www.w3.org/2001/04/xmlenc# xenc-schema.xsd
+        http://www.w3.org/2009/xmlenc11# xenc-schema-11.xsd
+        http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd"
+    ID="uk999999" entityID="https://idp.example.org/idp/shibboleth">
+
+    <Extensions>
+        <ukfedlabel:UKFederationMember orgID="ukforg9999"/>
+        <ukfedlabel:Software date="2016-11-17" fullVersion="3.3.0" name="Shibboleth" version="3"/>
+        <ukfedlabel:ExportOptIn date="2009-09-11"/>
+        <mdrpi:RegistrationInfo registrationAuthority="http://ukfederation.org.uk"
+            registrationInstant="2007-03-30T16:36:00Z">
+            <mdrpi:RegistrationPolicy xml:lang="en"
+                >http://ukfederation.org.uk/doc/mdrps-20130902</mdrpi:RegistrationPolicy>
+        </mdrpi:RegistrationInfo>
+        <mdattr:EntityAttributes xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <saml:Attribute Name="http://macedir.org/entity-category-support"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>https://refeds.org/category/code-of-conduct/v2</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>
+    </Extensions>
+    <IDPSSODescriptor
+        protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol">
+        <Extensions>
+            <shibmd:Scope regexp="false">example.org</shibmd:Scope>
+            <mdui:UIInfo>
+                <mdui:DisplayName xml:lang="en">An Example Entity</mdui:DisplayName>
+                <mdui:Description xml:lang="en">This is the identity provider for the example.org domain.</mdui:Description>
+                <mdui:Logo height="80" width="80">https://idp.example.org/images/heads_80x80.jpg</mdui:Logo>
+                <mdui:Logo height="43" width="100">https://idp.example.org/images/heads_100x43.jpg</mdui:Logo>
+                <mdui:Logo height="104" width="240">https://idp.example.org/images/heads_240x104.jpg</mdui:Logo>
+            </mdui:UIInfo>
+            <mdui:DiscoHints>
+                <mdui:IPHint>192.0.2.0/24</mdui:IPHint>
+                <mdui:DomainHint>example.org</mdui:DomainHint>
+                <mdui:GeolocationHint>geo:105.616257,-10.474895</mdui:GeolocationHint>
+            </mdui:DiscoHints>
+        </Extensions>
+        <KeyDescriptor>
+            <ds:KeyInfo>
+                <ds:X509Data>
+                    <ds:X509Certificate>
+                        MIIFqTCCA5GgAwIBAgIUHWEbwHJ4qTTl9Tc/iU5fXjFnAEIwDQYJKoZIhvcNAQEL
+                        BQAwZDELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0JyaXN0b2wxEDAOBgNVBAcMB0Jy
+                        aXN0b2wxDTALBgNVBAoMBEppc2MxDDAKBgNVBAsMA1QmSTEUMBIGA1UEAwwLZXhh
+                        bXBsZS5vcmcwHhcNMjMwNzE3MDgxNzQ5WhcNNDMwNzEyMDgxNzQ5WjBkMQswCQYD
+                        VQQGEwJHQjEQMA4GA1UECAwHQnJpc3RvbDEQMA4GA1UEBwwHQnJpc3RvbDENMAsG
+                        A1UECgwESmlzYzEMMAoGA1UECwwDVCZJMRQwEgYDVQQDDAtleGFtcGxlLm9yZzCC
+                        AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKhcZPLvOEkLTTDyVRVhXz2q
+                        bME+1DkMdg8JL123KcuGxucz7sorF9pj7SC94aWlic4sQ54O4/2X8CzL4yGDThuL
+                        opuTeB5QPD+y/xuvV8Il1CdG3MXzTAjFP3Oa2ggZKktWIkW2T0f8uVzpWhddP4Aa
+                        sp5uKbF7qDRs6TwUHhllhiXlDcSfbW5N8+LeS+15qoJzVha9og9D6wwNhThigcLw
+                        9muP8L6KkL+ATGz+ArvkOoC5bMueO8NM5iDlAUtNxviPzbqLtcufrAYm+lV2hwCo
+                        nKmAEvNQ6D0jhSxlyDl8/VYU9nwmV1cKETNfJi3zkMO6s/47tvHP0JbFF0tFPixI
+                        PbIh5jPT+U1CbzEzG62QUrNXYnueqR9x9iVeygjzM/Jc2u1Jh+amlUMjWI9SmYt9
+                        dRf4Y+6rtWdwVMi+5fDF/f2G7VR7kZNTHJgoCll/U4CuQ4dqhtDh/Wdr6ABfx/ao
+                        FcmjEhHCNw1aS55CcmqZj8GDSJPTGb/N2h3Zy2IrBqwp8JZom8ERlpYj2H5B1Gi5
+                        Ue26jnyO3DAi6aCN09RcZS8OZWOtFTjJ1d9Knv4kFtcOOV61wVsURJ8lV6oMelSw
+                        Qabl6/AqHfC7GP4rGNZHnAZa58YRBRCov+AZjip9IGY+YWKCl5zPYDVWfZMKQmST
+                        NoE2hw9WR287j23QIviHAgMBAAGjUzBRMB0GA1UdDgQWBBR/zhqQSzIXEraLCetw
+                        7M3ZHt4WIzAfBgNVHSMEGDAWgBR/zhqQSzIXEraLCetw7M3ZHt4WIzAPBgNVHRMB
+                        Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBlMlkz+jLyvonTufDzdqjv/6QY
+                        aANnPcIXAmmxTFlJOHOGf982pfXixFNt1c7wCs6PpQWVKoFGrhDO9IwIrgxgUY/+
+                        aLA/MKh8a2Sk9JYqA4YC6kNBb+jkWZalfOSNlQNoEGLKneEq+u2QN2RMELBSHwZD
+                        jqItaV4Ovfdmx3x6jSuRqsZ8yCl0KrqziwvoYPhdQBXjbrOwA/0nwOGn8RohEGfD
+                        FmRQwA0YfKtdIVCmMhpCV0guh4QMmviiJF/xMZNGRk/VhMyLfYvtRzqhL72MB8cf
+                        l9a56vhf/wk84GnOKyh0xXJdyxfeT3daATTi/suLG/mwnWR1WxHQpDIHv1rYZUj7
+                        5KCmSaD1XbZh2H+D2GVCC4LBZpR/HVej96kdr+RWLDl4leM0Mdi/IbqMFLur6te0
+                        IQD9BY585aec4lTkcSo3VY5HXvHC00G1xya48Q2sySCl8XY0gbV7rMh3Qf5ziBX6
+                        GiVAnYCkFVAza4qMyYKshqbLXOP+Zh/1gCstCGdYi4vBt4goe3Xpu2jtrJiLr9m1
+                        Jhk/Qm7A+S0vjXtShuaecfcd8mXSqZJ8G4yIcQxqF6cMwBVWl059LOrRYQ1UPeZx
+                        6/vfb7EfKuQfFOtHHdF5N9DTGIqBxjcq/SIZnD1ji5ftl+lDUzOaMS82wMBwFJ/r
+                        IrhKy4GrwvGT/y1q8Q==
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding"
+            Location="https://idp.example.org:8443/idp/profile/SAML1/SOAP/ArtifactResolution" index="1"/>
+        <ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+            Location="https://idp.example.org:8443/idp/profile/SAML2/SOAP/ArtifactResolution" index="2"/>
+        <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+        <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+        <SingleSignOnService Binding="urn:mace:shibboleth:1.0:profiles:AuthnRequest"
+            Location="https://idp.example.org/idp/profile/Shibboleth/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            Location="https://idp.example.org/idp/profile/SAML2/POST/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+            Location="https://idp.example.org/idp/profile/SAML2/POST-SimpleSign/SSO"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            Location="https://idp.example.org/idp/profile/SAML2/Redirect/SSO"/>
+    </IDPSSODescriptor>
+    <Organization>
+        <OrganizationName xml:lang="en">An Example Organization</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">An Example Organization</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">http://example.org/</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="support">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:ukfed@example.org</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="technical">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:ukfed@example.org</EmailAddress>
+    </ContactPerson>
+    <ContactPerson contactType="administrative">
+        <GivenName>An</GivenName>
+        <SurName>Example</SurName>
+        <EmailAddress>mailto:anexample@example.org</EmailAddress>
+    </ContactPerson>
+</EntityDescriptor>

--- a/validators/overlays/all/classes/_rules/check_coco_v2_support.xsl
+++ b/validators/overlays/all/classes/_rules/check_coco_v2_support.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    check_coco_v2_support.xsl
+
+    Checking ruleset containing rules associated with the REFEDS
+    Data Protection Code of Conduct Entity Category category support, see:
+
+    https://refeds.org/category/code-of-conduct/v2
+
+    This ruleset reflects v2.0 published 28th March 2022
+
+-->
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+
+    <!--
+        Common support functions.
+    -->
+    <xsl:import href="check_framework.xsl"/>
+
+    <!--
+        Entity support category applies only to identity providers.
+    -->
+    <xsl:template match="md:EntityDescriptor
+        [
+            md:Extensions/mdattr:EntityAttributes/saml:Attribute
+                [@NameFormat='urn:oasis:names:tc:SAML:2.0:attrname-format:uri']
+                [@Name='http://macedir.org/entity-category-support']
+                /saml:AttributeValue[.='https://refeds.org/category/code-of-conduct/v2']
+        ]
+        [not(md:IDPSSODescriptor)]">
+        <xsl:call-template name="error">
+            <xsl:with-param name="m">REFEDS Data Protection Code of Conduct support only applies to identity provider entities</xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/validators/overlays/all/classes/default-validator-stages.xml
+++ b/validators/overlays/all/classes/default-validator-stages.xml
@@ -13,6 +13,7 @@
        <ref bean="check_entityid_prefix"/>
        <ref bean="check_saml2"/>
        <ref bean="check_mdrpi_xslt"/>
+       <ref bean="check_coco_v2_support"/>
     </util:list>
 
 </beans>

--- a/validators/overlays/all/classes/default-validator.xml
+++ b/validators/overlays/all/classes/default-validator.xml
@@ -35,6 +35,12 @@
     <bean id="check_mdrpi_xslt" parent="mda.XSLValidationStage"
         p:XSLResource="classpath:_rules/check_mdrpi.xsl"/>
 
+    <!--
+        check_coco_v2_support
+    -->
+    <bean id="check_coco_v2_support" parent="mda.XSLValidationStage"
+        p:XSLResource="classpath:_rules/check_coco_v2_support.xsl"/>
+
     <bean id="pipeline" parent="mda.SimplePipeline">
         <property name="stages" ref="default_validator_stages"/>
     </bean>


### PR DESCRIPTION
Tests pass with both Xalan and non-xalan XSLT processors. No ruleset changes are required.